### PR TITLE
fixed premake

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,8 +10,7 @@ class Csvparserrfc4180jinq0123Conan(ConanFile):
     generators = "Premake"  # A custom generator: PremakeGen/0.1@memsharded/testing
     exports_sources = "csv_parser/csv_parser.*", "premake5.lua"
 
-    def requirements(self):
-        self.requires("PremakeGen/0.1@memsharded/testing")
+    build_requires = "PremakeGen/0.1@memsharded/testing"
      
     def build(self):
         if self.settings.compiler == "Visual Studio":
@@ -22,6 +21,8 @@ class Csvparserrfc4180jinq0123Conan(ConanFile):
                     "csv_parser_RFC4180.sln",
                     targets=["csv_parser_RFC4180"],
                     upgrade_project = False)
+                if self.settings.arch == "x86":
+                    cmd = cmd.replace('p:Platform="x86"', 'p:Platform="Win32"')
                 self.run(cmd)
         # End of if.
 


### PR DESCRIPTION
It seems that premake insists on using the platform name "Win32", irrespective of what you configure in premake5.lua. I have tried changing the platforms and using ```filter`` without success. Maybe some premake expert or an issue in the premake repos could help.

In the meantime, I propose this workaround.

As a side issue, it seems is also possible to depend on the premake generator only as ``build_requires``.

Also, if you plan to use premake extensively, it seems easy to create a package for premake itself, so you get installed it also in CI and new machines, easily, also as ``build_requires``